### PR TITLE
solve compilation error at GCC version >=6

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -783,7 +783,7 @@ namespace cryptonote
   {
     if (block_sync_size > 0)
       return block_sync_size;
-      return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
+    return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
   }
   //-----------------------------------------------------------------------------------------------
   bool core::are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent) const


### PR DESCRIPTION
solve compilation error at GCC version >=6
A new warning -Wmisleading-indentation was added to -Wall, warning about places where the indentation of the code might mislead a human reader about the control flow