### PR TITLE
Update stale bitmonero reference

### DIFF
--- a/src/daemonizer/posix_fork.cpp
+++ b/src/daemonizer/posix_fork.cpp
@@ -120,7 +120,7 @@ void fork(const std::string & pidfile)
   if (!tmpdir)
     tmpdir = TMPDIR;
   std::string output = tmpdir;
-  output += "/bitmonero.daemon.stdout.stderr";
+  output += "/edollar.daemon.stdout.stderr";
   const int flags = O_WRONLY | O_CREAT | O_APPEND;
   const mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
   if (open(output.c_str(), flags, mode) < 0)


### PR DESCRIPTION
Update a stale bitmonero reference so edollard can run concurrently on the same machine.